### PR TITLE
BUGFIX: Creation of table stock_status_index failed

### DIFF
--- a/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.1.4-1.1.5.php
+++ b/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.1.4-1.1.5.php
@@ -6,12 +6,12 @@ $installer->startSetup();
 $table = $installer->getConnection()
     ->newTable($installer->getTable('demac_multilocationinventory/stock_status_index'))
     ->addColumn('store_id', Varien_Db_Ddl_Table::TYPE_SMALLINT, null, array(
-        'length'=>5,
+        'length'   => 5,
         'unsigned' => true,
         'nullable' => false
     ), 'Location ID')
     ->addColumn('product_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
-        'length'=>10,
+        'length'   => 10,
         'unsigned' => true,
         'nullable' => false
     ), 'Product ID')


### PR DESCRIPTION
because the columns which references to the foreign key columns must be equal to them: size and signed/unsigned. So I've added the correct size and type to those two columns.

Can you confirm that or will it only happen on my database?

Check check check ...

I've just found the original table structure of a fresh 1.8.1.0 install:

Table structure for `core_store`

```
DROP TABLE IF EXISTS `core_store`;
/*!40101 SET @saved_cs_client     = @@character_set_client */;
/*!40101 SET character_set_client = utf8 */;
CREATE TABLE `core_store` (
  `store_id` smallint(5) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Store Id',
  `code` varchar(32) DEFAULT NULL COMMENT 'Code',
  `website_id` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Website Id',

```

and `catalog_product_entity`:

```
DROP TABLE IF EXISTS `catalog_product_entity`;
/*!40101 SET @saved_cs_client     = @@character_set_client */;
/*!40101 SET character_set_client = utf8 */;
CREATE TABLE `catalog_product_entity` (
  `entity_id` int(10) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Entity ID',
  `entity_type_id` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Entity Type ID',
  `attribute_set_id` smallint(5) unsigned NOT NULL DEFAULT '0' COMMENT 'Attribute Set ID',
```

So it seems that maybe other use should also run into that installation issue ...

This is a really cool module. I've got a lot of inspiration from it :+1: 
