### PR TITLE
Fix issue that children products qty is no decremented correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Code Climate](https://codeclimate.com/github/DemacMedia/Magento-Multi-Location-Inventory.png)](https://codeclimate.com/github/DemacMedia/Magento-Multi-Location-Inventory)
 
-#Multi Location Inventory v1.2.4
+#Multi Location Inventory v1.2.5
 ##Description
 Allows the creation of multiple inventory locations in Magento along with assigning those inventory locations to store views.
 

--- a/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Location/Edit.php
+++ b/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Location/Edit.php
@@ -24,6 +24,10 @@ class Demac_MultiLocationInventory_Block_Adminhtml_Location_Edit extends Mage_Ad
             'onclick' => 'saveAndContinueEdit()',
             'class'   => 'save',
         ), -100);
+
+        $this->_formScripts[] = 'function saveAndContinueEdit() {
+            editForm.submit($("edit_form").action + \'back/edit/\');
+        }';
     }
 
     /**

--- a/app/code/community/Demac/MultiLocationInventory/Helper/Location.php
+++ b/app/code/community/Demac/MultiLocationInventory/Helper/Location.php
@@ -20,7 +20,7 @@ class Demac_MultiLocationInventory_Helper_Location extends Mage_Core_Helper_Abst
 
         $locationsCollection = Mage::getModel('demac_multilocationinventory/location')
             ->getCollection()
-            ->joinStockDataOnProductAndStoreView();
+            ->joinStockDataOnProductAndStoreView(false, $storeId);
         $locationsCollection
             ->getSelect()
             ->group('main_table.id');

--- a/app/code/community/Demac/MultiLocationInventory/Model/Observer.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Observer.php
@@ -60,13 +60,15 @@ class Demac_MultiLocationInventory_Model_Observer
             $quoteItems             = $observer->getEvent()->getQuote()->getAllItems();
 
             foreach ($quoteItems as $quoteItem) {
-                if(sizeof($quoteItem->getChildren()) == 0) {
-                    $updatedProducts[] = $quoteItem->getProductId();
+                $updatedProducts[] = $quoteItem->getProductId();
 
-                    $this->checkoutProducts[$quoteItem->getId()] = $quoteItem->getQty();
-                    if(!is_null($quoteItem->getParentItem())) {
-                        $this->checkoutProducts[$quoteItem->getId()] = $quoteItem->getParentItem()->getQty();
+                $children = $quoteItem->getChildrenItems();
+                if ($children) {
+                    foreach ($children as $childItem) {
+                        $this->checkoutProducts[$childItem->getId()] = $childItem->getTotalQty();
                     }
+                } else {
+                    $this->checkoutProducts[$quoteItem->getId()] = $quoteItem->getTotalQty();
                 }
             }
 


### PR DESCRIPTION
When dealing with children products and you order, for example 2 of the main product but that contains 2 of the children then children would never be decremented by the right value.

Change the code to use `getTotalQty` rather than `getQty` should fix this issue.

This pull request should fix https://github.com/DemacMedia/Magento-Multi-Location-Inventory/issues/37 

Also fixes an issue that when building locations to decrease qty it is not filtering by store code.

https://github.com/DemacMedia/Magento-Multi-Location-Inventory/issues/36
https://github.com/DemacMedia/Magento-Multi-Location-Inventory/issues/30