### PR TITLE
Bundle product index, threshold on product location level and import addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Code Climate](https://codeclimate.com/github/DemacMedia/Magento-Multi-Location-Inventory.png)](https://codeclimate.com/github/DemacMedia/Magento-Multi-Location-Inventory)
 
-#Multi Location Inventory v1.2.5
+#Multi Location Inventory v1.2.7
 ##Description
 Allows the creation of multiple inventory locations in Magento along with assigning those inventory locations to store views.
 
@@ -48,6 +48,15 @@ Please contribute other extensions you find that are not compatible either by se
 ##Finding Your Way Around (Customization)
 Below is a list of several major components of this extension that should help you to get started with it.
 
+###Batch importing
+Bulk uploads of inventory data can be done using the core ImportExport module.
+Similar to specifying data per store view using the `_store` column, you can include a `stock_location` column in your spreadsheet.
+The corresponding values in each row should be the code of the location you wish to import data against.
+You can then include multiple rows per product containing data for `qty`, `is_in_stock`, `backorders`, etc.
+
+Download a sample CSV import [here](https://github.com/DemacMedia/Magento-Multi-Location-Inventory/blob/master/sample_import.csv).
+
+***Note:*** *Import currently only works with data set against the default level and not the store level*
 
 ###Inventory Reduction On Checkout
 It is recommended to disable this functionality and allow integrations to push inventory updates. The easiest way to disable this functionality is to set the following config setting: Configuration > Catalog > Inventory > Stock Options > Decrease stock when order is placed

--- a/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Catalog/Product/Edit/Multilocationinventory.php
+++ b/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Catalog/Product/Edit/Multilocationinventory.php
@@ -108,7 +108,7 @@ class Demac_MultiLocationInventory_Block_Adminhtml_Catalog_Product_Edit_Multiloc
     /**
      * Get inventory within the current store view scope.
      *
-     * @return array
+     * @return float
      */
     public function getScopeInventory()
     {
@@ -118,7 +118,7 @@ class Demac_MultiLocationInventory_Block_Adminhtml_Catalog_Product_Edit_Multiloc
     /**
      * Get global inventory.
      *
-     * @return array
+     * @return float
      */
     public function getGlobalInventory()
     {
@@ -133,13 +133,14 @@ class Demac_MultiLocationInventory_Block_Adminhtml_Catalog_Product_Edit_Multiloc
         $productId   = $this->getProductId();
         $storeViewId = $this->getStoreViewId();
 
-        $locationStockCollection = Mage::getModel('demac_multilocationinventory/location')
-            ->getCollection()
-            ->joinStockDataOnProductAndStoreView($productId, $storeViewId);
+        /** @var Demac_MultiLocationInventory_Model_Resource_Location_Collection $locationStockCollection */
+        $locationStockCollection = Mage::getModel('demac_multilocationinventory/location')->getCollection();
+        $locationStockCollection->joinStockDataOnProductAndStoreView($productId, $storeViewId);
 
         $locations = array();
         foreach ($locationStockCollection as $locationStock) {
             $locationStock->setQty(floatval($locationStock->getQty()));
+            $locationStock->setMinQty(floatval($locationStock->getMinQty()));
             $this->scopeInventory += $locationStock->getQty();
             array_push($locations, $locationStock->toArray());
         }
@@ -149,9 +150,13 @@ class Demac_MultiLocationInventory_Block_Adminhtml_Catalog_Product_Edit_Multiloc
 
     /**
      * Load global inventory.
+     *
+     * @param int $productId
      */
     private function loadGlobalInventory($productId)
     {
-        $this->globalInventory = Mage::getModel('demac_multilocationinventory/stock')->getGlobalInventory($productId);
+        /** @var Demac_MultiLocationInventory_Model_Stock $stock */
+        $stock = Mage::getModel('demac_multilocationinventory/stock');
+        $this->globalInventory = $stock->getGlobalInventory($productId);
     }
 }

--- a/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Location/Edit/Tab/Location.php
+++ b/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Location/Edit/Tab/Location.php
@@ -140,6 +140,13 @@ class Demac_MultiLocationInventory_Block_Adminhtml_Location_Edit_Tab_Location ex
             'name'     => 'name',
         ));
 
+        $fieldset->addField('code', 'text', array(
+            'label'    => $this->__('Code'),
+            'class'    => 'required-entry',
+            'required' => true,
+            'name'     => 'code',
+        ));
+
         $fieldset->addField('external_id', 'text', array(
             'label'    => $this->__('External ID'),
             'required' => false,

--- a/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Location/Grid.php
+++ b/app/code/community/Demac/MultiLocationInventory/Block/Adminhtml/Location/Grid.php
@@ -59,6 +59,13 @@ class Demac_MultiLocationInventory_Block_Adminhtml_Location_Grid extends Mage_Ad
                          )
         );
 
+        $this->addColumn('code',
+            array(
+                'header' => $this->__('Code'),
+                'index'  => 'code'
+            )
+        );
+
         $this->addColumn('name',
                          array(
                              'header' => $this->__('Name'),

--- a/app/code/community/Demac/MultiLocationInventory/Model/Admin/Observer.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Admin/Observer.php
@@ -89,6 +89,7 @@ class Demac_MultiLocationInventory_Model_Admin_Observer
         if(isset($this->inputData[$locationId])) {
             $inputStock = $this->inputData[$locationId];
             $_stock->setQty($inputStock['quantity']);
+            $_stock->setMinQty($inputStock['min_qty']);
             $_stock->setBackorders($inputStock['backorders']);
             $_stock->setIsInStock($inputStock['is_in_stock']);
             $_stock->setManageStock($inputStock['manage_stock']);

--- a/app/code/community/Demac/MultiLocationInventory/Model/CatalogInventory/Stock/Item.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/CatalogInventory/Stock/Item.php
@@ -27,4 +27,47 @@ class Demac_MultiLocationInventory_Model_CatalogInventory_Stock_Item extends Mag
         return $this;
     }
 
+    /**
+     * Check quantity
+     *  - Loop through all locations/product links for given store, when you find one that has the right amount
+     *      return true otherwise return false with the error,
+     *
+     * @param   decimal $qty
+     * @exception Mage_Core_Exception
+     * @return  bool
+     */
+    public function checkQty($qty)
+    {
+        if (!$this->getManageStock() || Mage::app()->getStore()->isAdmin()) {
+            return true;
+        }
+
+        $availableQty = 0;
+
+        /** @var Demac_MultiLocationInventory_Model_Resource_Location_Collection $locations */
+        $locations = Mage::getModel('demac_multilocationinventory/location')->getCollection();
+        $locations->joinStockDataOnProductAndStoreView($this->getProductId(), Mage::app()->getStore()->getId());
+
+        foreach ($locations as $location) {
+            $locationAvailableQty = $location->getQty() - $location->getMinQty();
+
+            // We have more requested from this location than we have
+            if ($locationAvailableQty - ($qty - $availableQty) >= 0) {
+                return true;
+            } else {
+                $availableQty += $locationAvailableQty;
+
+                switch ($this->getBackorders()) {
+                    case Mage_CatalogInventory_Model_Stock::BACKORDERS_YES_NONOTIFY:
+                    case Mage_CatalogInventory_Model_Stock::BACKORDERS_YES_NOTIFY:
+                        return true;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/app/code/community/Demac/MultiLocationInventory/Model/Importexport/Observer.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Importexport/Observer.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Class Demac_MultiLocationInventory_Model_Importexport_Observer
+ */
+class Demac_MultiLocationInventory_Model_Importexport_Observer
+{
+    const COL_SKU            = 'sku';
+    const COL_STOCK_LOCATION = 'stock_location';
+
+    /** @var array */
+    protected $locationIds = array();
+
+    /** @var array */
+    protected $defaultStockData = array(
+        'manage_stock'              => 1,
+        'use_config_manage_stock'   => 1,
+        'qty'                       => 0,
+        'backorders'                => 0,
+        'use_config_backorders'     => 1,
+        'is_in_stock'               => 0
+    );
+
+    /** @var string */
+    protected $stockTable;
+
+    /** @var array */
+    protected $stockData = array();
+
+    /**
+     * Build up the locations for use later on
+     */
+    public function __construct()
+    {
+        $this->_initLocations();
+
+        $this->stockTable = Mage::getResourceModel('demac_multilocationinventory/stock')->getMainTable();
+    }
+
+    /**
+     * Load all location IDs
+     *
+     * @return $this
+     */
+    private function _initLocations()
+    {
+        /** @var Demac_MultiLocationInventory_Model_Resource_Location_Collection $collection */
+        $collection = Mage::getModel('demac_multilocationinventory/location')->getCollection();
+        $collection->addFieldToSelect('id');
+        $collection->addFieldToSelect('code');
+
+        /** @var Demac_MultiLocationInventory_Model_Location $location */
+        foreach($collection as $location) {
+            $this->locationIds[$location->getCode()] = $location->getId();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Loop through all rows of the import and save the inventory data
+     *
+     * @param Varien_Event_Observer $observer
+     * @return $this
+     */
+    public function importMultiLocationInventory(Varien_Event_Observer $observer)
+    {
+        /** @var Mage_ImportExport_Model_Import_Entity_Product $adapter */
+        $adapter = $observer->getData('adapter');
+        if(!$adapter) {
+            return $this;
+        }
+
+        // Only process replace or append imports
+        if (Mage_ImportExport_Model_Import::BEHAVIOR_DELETE == $adapter->getBehavior()) {
+            return $this;
+        }
+
+        $newSku = $adapter->getNewSku();
+        $sku    = false;
+
+        while ($bunch = $adapter->getNextBunch()) {
+            $this->resetStockData();
+
+            // Format bunch to stock data rows
+            foreach ($bunch as $rowNum => $rowData) {
+                $this->filterRowData($rowData);
+                if (!$adapter->isRowAllowedToImport($rowData, $rowNum)) {
+                    continue;
+                }
+
+                $rowScope = $adapter->getRowScope($rowData);
+                if (Mage_ImportExport_Model_Import_Entity_Product::SCOPE_DEFAULT == $rowScope) {
+                    $sku = $rowData[self::COL_SKU];
+                } elseif (!$sku) {
+                    continue;
+                }
+
+                if (!isset($rowData[self::COL_STOCK_LOCATION])) {
+                    continue;
+                }
+
+                $locationCode = $rowData[self::COL_STOCK_LOCATION];
+                // Check to see if we have this location code in the DB
+                if(!$this->isStoredLocation($locationCode)) {
+                    continue;
+                }
+
+                $productId = $newSku[$sku]['entity_id'];
+                $this->buildStockData($locationCode, $productId, $rowData);
+            }
+
+            // Insert rows
+            if ($this->stockData) {
+                $adapter->getConnection()->insertOnDuplicate($this->stockTable, $this->stockData);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Removes empty keys in case value is null or empty string
+     *
+     * @param array $rowData
+     */
+    protected function filterRowData(&$rowData)
+    {
+        $rowData = array_filter($rowData, 'strlen');
+        // Exceptions - for sku - put them back in
+        if (!isset($rowData[self::COL_SKU])) {
+            $rowData[self::COL_SKU] = null;
+        }
+    }
+
+    /**
+     * Check to see if we have a given location code in the database
+     *
+     * @param string $locationCode
+     * @return bool
+     */
+    private function isStoredLocation($locationCode)
+    {
+        return array_key_exists($locationCode, $this->locationIds);
+    }
+
+    /**
+     * Build the stock data array for a given location/product combination
+     *
+     * @param string $locationCode
+     * @param int $productId
+     * @param array $rowData
+     */
+    private function buildStockData($locationCode, $productId, $rowData)
+    {
+        $locationId = $this->locationIds[$locationCode];
+
+        $row = array();
+        $row['location_id'] = $locationId;
+        $row['product_id']  = $productId;
+        if (isset($rowData['qty'])) {
+            $row['qty'] = $rowData['qty'];
+        }
+        if (isset($rowData['backorders'])) {
+            $row['backorders'] = $rowData['backorders'];
+        }
+
+        /** @var $stockItem Demac_MultiLocationInventory_Model_Stock */
+        $stockItem = Mage::getModel('demac_multilocationinventory/stock');
+        $stockItem->loadByProduct($locationId, $productId);
+        $existStockData = $stockItem->getData();
+
+        $row = array_merge(
+            $this->defaultStockData,
+            array_intersect_key($existStockData, $this->defaultStockData),
+            array_intersect_key($rowData, $this->defaultStockData),
+            $row
+        );
+
+        $stockItem->setData($row);
+
+        $this->stockData[] = $stockItem->unsetOldData()->getData();
+    }
+
+    /**
+     * Reset the internal stock data array
+     */
+    private function resetStockData()
+    {
+        $this->stockData = array();
+    }
+}

--- a/app/code/community/Demac/MultiLocationInventory/Model/Location.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Location.php
@@ -13,4 +13,13 @@ class Demac_MultiLocationInventory_Model_Location extends Mage_Core_Model_Abstra
         parent::_construct();
         $this->_init('demac_multilocationinventory/location');
     }
+
+    /**
+     * @param string $code
+     * @return int|false
+     */
+    public function getIdByCode($code)
+    {
+        return $this->_getResource()->getIdByCode($code);
+    }
 }

--- a/app/code/community/Demac/MultiLocationInventory/Model/Resource/Location.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Resource/Location.php
@@ -176,4 +176,23 @@ class Demac_MultiLocationInventory_Model_Resource_Location extends Mage_Core_Mod
     {
         return Mage::app()->getStore($this->_store);
     }
+
+    /**
+     * Get location identifier by code
+     *
+     * @param string $code
+     * @return int|false
+     */
+    public function getIdByCode($code)
+    {
+        $adapter = $this->_getReadAdapter();
+
+        $select = $adapter->select()
+            ->from($this->getTable('demac_multilocationinventory/location'), 'id')
+            ->where('code = :code');
+
+        $bind = array(':code' => (string)$code);
+
+        return $adapter->fetchOne($select, $bind);
+    }
 }

--- a/app/code/community/Demac/MultiLocationInventory/Model/Resource/Location/Collection.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Resource/Location/Collection.php
@@ -124,7 +124,13 @@ class Demac_MultiLocationInventory_Model_Resource_Location_Collection extends Ma
                     'stock' => Mage::getSingleton('core/resource')->getTableName('demac_multilocationinventory/stock')
                 ),
                 'main_table.id = stock.location_id',
-                array('stock.qty', 'stock.backorders', 'stock.is_in_stock', 'stock.manage_stock')
+                array(
+                    'stock.qty',
+                    'stock.min_qty',
+                    'stock.backorders',
+                    'stock.is_in_stock',
+                    'stock.manage_stock'
+                )
             );
 
         $this
@@ -163,4 +169,11 @@ class Demac_MultiLocationInventory_Model_Resource_Location_Collection extends Ma
         return $this;
     }
 
+    /**
+     * @return Varien_Data_Collection_Db
+     */
+    public function reset()
+    {
+        return $this->_reset();
+    }
 }

--- a/app/code/community/Demac/MultiLocationInventory/etc/config.xml
+++ b/app/code/community/Demac/MultiLocationInventory/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Demac_MultiLocationInventory>
-            <version>1.2.5</version>
+            <version>1.2.8</version>
         </Demac_MultiLocationInventory>
     </modules>
     <global>
@@ -10,11 +10,19 @@
             <checkout_submit_all_after>
                 <observers>
                     <multilocationinventory_submit_all_after>
-                        <class>Demac_MultiLocationInventory_Model_Observer</class>
+                        <class>demac_multilocationinventory/observer</class>
                         <method>checkoutAllSubmitAfter</method>
                     </multilocationinventory_submit_all_after>
                 </observers>
             </checkout_submit_all_after>
+            <catalog_product_import_finish_before>
+                <observers>
+                    <multi_location_inventory_import>
+                        <class>demac_multilocationinventory/importexport_observer</class>
+                        <method>importMultiLocationInventory</method>
+                    </multi_location_inventory_import>
+                </observers>
+            </catalog_product_import_finish_before>
         </events>
         <index>
             <indexer>
@@ -70,6 +78,7 @@
                 <resourceModel>cataloginventory_resource</resourceModel>
                 <rewrite>
                     <stock>Demac_MultiLocationInventory_Model_CatalogInventory_Stock</stock>
+                    <stock_item>Demac_MultiLocationInventory_Model_CatalogInventory_Stock_Item</stock_item>
                     <observer>Demac_MultiLocationInventory_Model_CatalogInventory_Observer</observer>
                 </rewrite>
             </cataloginventory>

--- a/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.5-1.2.6.php
+++ b/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.5-1.2.6.php
@@ -1,0 +1,832 @@
+<?php
+$installer = $this;
+
+$installer->startSetup();
+
+
+$sql = '
+DROP PROCEDURE IF EXISTS `DEMAC_MLI_REINDEX_SET`;
+CREATE PROCEDURE `DEMAC_MLI_REINDEX_SET` (reindex_entity_ids TEXT)
+BEGIN
+  UPDATE demac_multilocationinventory_stock_status_index dest, 
+       (SELECT stock.product_id                                      AS 
+               product_id, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum( 
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, 
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               stores.store_id                                       AS store_id 
+        FROM   demac_multilocationinventory_stock AS stock 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+               JOIN catalog_product_entity AS product_entity 
+                 ON stock.product_id = product_entity.entity_id 
+               JOIN demac_multilocationinventory_stores AS stores 
+                 ON stock.location_id = stores.location_id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id IN ("simple", "giftcard")
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY Concat(stores.store_id, "_", stock.product_id) 
+        UNION 
+        SELECT stock.product_id                                      AS 
+               product_id, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum( 
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, 
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               0                                                     AS store_id 
+        FROM   demac_multilocationinventory_stock AS stock 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+               JOIN catalog_product_entity AS product_entity 
+                 ON stock.product_id = product_entity.entity_id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id IN ("simple", "giftcard")
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY stock.product_id 
+        UNION 
+        SELECT product_entity.entity_id 
+               AS product_id, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF( 
+               Sum(IF(stock.is_in_stock = 
+                      1, stock.qty, 0)) 
+               AND 
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF( 
+               Sum(IF(stock.is_in_stock = 
+                      1, stock.qty, 0)) 
+               AND 
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock,
+               stores.store_id                                       AS store_id
+        FROM   catalog_product_entity AS product_entity 
+               JOIN catalog_product_super_link AS link 
+                 ON product_entity.entity_id = link.parent_id 
+               JOIN demac_multilocationinventory_stock AS stock 
+                 ON link.product_id = stock.product_id 
+               JOIN demac_multilocationinventory_stores AS stores 
+                 ON stock.location_id = stores.location_id 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "configurable"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY Concat(stores.store_id, "_", product_entity.entity_id) 
+        UNION 
+        SELECT product_entity.entity_id 
+               AS product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF( 
+               Sum(IF(stock.is_in_stock = 
+                      1, stock.qty, 0)) 
+               AND 
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF( 
+               Sum(IF(stock.is_in_stock = 
+                      1, stock.qty, 0)) 
+               AND 
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock,
+               0                                                     AS store_id
+        FROM   catalog_product_entity AS product_entity 
+               JOIN catalog_product_super_link AS link 
+                 ON product_entity.entity_id = link.parent_id 
+               JOIN demac_multilocationinventory_stock AS stock 
+                 ON link.product_id = stock.product_id 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "configurable"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY product_entity.entity_id 
+        UNION 
+        SELECT product_entity.entity_id                              AS 
+               product_id, 
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0)) 
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS qty, 
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0)) 
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               stores.store_id                                       AS store_id 
+        FROM   catalog_product_entity AS product_entity 
+               JOIN catalog_product_link AS link 
+                 ON product_entity.entity_id = link.product_id 
+               JOIN demac_multilocationinventory_stock AS stock 
+                 ON link.linked_product_id = stock.product_id 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+               JOIN demac_multilocationinventory_stores AS stores 
+                 ON stock.location_id = stores.location_id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "grouped"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY Concat(stores.store_id, "_", product_entity.entity_id) 
+        UNION 
+        SELECT product_entity.entity_id                              AS 
+               product_id, 
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0)) 
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS qty, 
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0)) 
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               0                                                     AS store_id 
+        FROM   catalog_product_entity AS product_entity 
+               JOIN catalog_product_link AS link 
+                 ON product_entity.entity_id = link.product_id 
+               JOIN demac_multilocationinventory_stock AS stock 
+                 ON link.linked_product_id = stock.product_id 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "grouped"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY product_entity.entity_id 
+        UNION 
+        SELECT stock.product_id                                      AS 
+               product_id, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum( 
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, 
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               stores.store_id                                       AS store_id 
+        FROM   demac_multilocationinventory_stock AS stock 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+               JOIN catalog_product_entity AS product_entity 
+                 ON stock.product_id = product_entity.entity_id 
+               JOIN demac_multilocationinventory_stores AS stores 
+                 ON stock.location_id = stores.location_id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "virtual"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids) 
+        GROUP  BY Concat(stores.store_id, "_", stock.product_id) 
+        UNION 
+        SELECT stock.product_id                                      AS 
+               product_id, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum( 
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, 
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               0                                                     AS store_id 
+        FROM   demac_multilocationinventory_stock AS stock 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+               JOIN catalog_product_entity AS product_entity 
+                 ON stock.product_id = product_entity.entity_id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "virtual"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY stock.product_id 
+        UNION 
+        SELECT stock.product_id                                      AS 
+               product_id, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum( 
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, 
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               stores.store_id                                       AS store_id 
+        FROM   demac_multilocationinventory_stock AS stock 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+               JOIN catalog_product_entity AS product_entity 
+                 ON stock.product_id = product_entity.entity_id 
+               JOIN demac_multilocationinventory_stores AS stores 
+                 ON stock.location_id = stores.location_id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "downloadable"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY Concat(stores.store_id, "_", stock.product_id) 
+        UNION 
+        SELECT stock.product_id                                      AS 
+               product_id, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum( 
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, 
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS 
+               is_in_stock, 
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS 
+               backorders, 
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS 
+               manage_stock, 
+               0                                                     AS store_id 
+        FROM   demac_multilocationinventory_stock AS stock 
+               JOIN demac_multilocationinventory_location AS location 
+                 ON stock.location_id = location.id 
+               JOIN catalog_product_entity AS product_entity 
+                 ON stock.product_id = product_entity.entity_id 
+        WHERE  location.status = 1 
+               AND product_entity.type_id = "downloadable"
+               AND FIND_IN_SET(product_entity.entity_id, reindex_entity_ids)
+        GROUP  BY stock.product_id) src 
+SET    dest.qty = src.qty, 
+       dest.is_in_stock = src.is_in_stock, 
+       dest.backorders = src.backorders, 
+       dest.manage_stock = src.manage_stock 
+WHERE  dest.store_id = src.store_id 
+       AND dest.product_id = src.product_id;
+
+-- BUNDLE SECTION
+-- check if all fields are optional
+CREATE temporary TABLE IF NOT EXISTS
+demac_multilocationinventory_bundled_indexer_tmp AS
+  (SELECT catalog_product_entity.entity_id,
+          Sum(catalog_product_bundle_option.required) AS required_count
+   FROM   catalog_product_entity
+          JOIN catalog_product_bundle_option
+            ON catalog_product_bundle_option.parent_id =
+               catalog_product_entity.entity_id
+   WHERE  type_id = "bundle"
+   AND FIND_IN_SET(catalog_product_entity.entity_id, reindex_entity_ids)
+   GROUP  BY catalog_product_entity.entity_id);
+
+-- ALL OPTIONAL: get all child products, if sum of is_in_stock > 0 then set is_in_stock = 1 and qty = some really big number
+-- GLOBAL:
+UPDATE
+    demac_multilocationinventory_stock_status_index dest,
+   (SELECT catalog_product_bundle_selection.parent_product_id AS product_id,
+           IF(Sum(is_in_stock) > 0, 1, 0)                     AS qty,
+           IF(Sum(is_in_stock) > 0, 1, 0)                     AS is_in_stock
+    FROM   catalog_product_bundle_selection
+           JOIN demac_multilocationinventory_bundled_indexer_tmp
+             ON demac_multilocationinventory_bundled_indexer_tmp.entity_id =
+                catalog_product_bundle_selection.parent_product_id
+           JOIN demac_multilocationinventory_stock
+             ON demac_multilocationinventory_stock.product_id =
+                catalog_product_bundle_selection.product_id
+    WHERE  required_count = 0
+    AND
+        FIND_IN_SET(catalog_product_bundle_selection.parent_product_id, reindex_entity_ids)
+    GROUP  BY catalog_product_bundle_selection.parent_product_id) src
+SET
+    dest.qty = src.qty,
+    dest.is_in_stock = src.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = 0
+AND
+    dest.product_id = src.product_id;
+
+-- STORE SPECIFIC:
+UPDATE demac_multilocationinventory_stock_status_index dest,
+    (SELECT demac_multilocationinventory_stores.store_id                        AS store_id,
+           catalog_product_bundle_selection.parent_product_id                   AS product_id,
+           IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0)    AS qty,
+           IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0)    AS is_in_stock
+    FROM   catalog_product_bundle_selection
+        JOIN demac_multilocationinventory_bundled_indexer_tmp
+            ON demac_multilocationinventory_bundled_indexer_tmp.entity_id = catalog_product_bundle_selection.parent_product_id
+        JOIN demac_multilocationinventory_stock
+            ON demac_multilocationinventory_stock.product_id = catalog_product_bundle_selection.product_id
+        JOIN demac_multilocationinventory_stores
+            ON demac_multilocationinventory_stock.location_id = demac_multilocationinventory_stores.location_id
+    WHERE
+        required_count = 0
+    AND
+        FIND_IN_SET(catalog_product_bundle_selection.parent_product_id, reindex_entity_ids)
+    GROUP BY
+        Concat(catalog_product_bundle_selection.parent_product_id, "_",demac_multilocationinventory_stores.store_id)
+    ) src
+SET
+    dest.qty = src.qty,
+    dest.is_in_stock = src.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = src.store_id
+AND
+    dest.product_id = src.product_id;
+
+-- SOME REQUIRED: Verify that each required option has at least one child item in stock (sum is_in_stock grouped by option, if all are greater than 1)
+-- GLOBAL:
+UPDATE
+    demac_multilocationinventory_stock_status_index dest,
+    (SELECT src.product_id AS product_id,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS is_in_stock,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS qty
+    FROM
+        (SELECT catalog_product_bundle_selection.option_id AS option_id,
+            catalog_product_bundle_selection.parent_product_id AS product_id,
+            IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0) AS is_in_stock
+        FROM
+            catalog_product_bundle_selection
+        JOIN demac_multilocationinventory_bundled_indexer_tmp
+            ON demac_multilocationinventory_bundled_indexer_tmp.entity_id = catalog_product_bundle_selection.parent_product_id
+        JOIN catalog_product_bundle_option
+            ON catalog_product_bundle_option.option_id = catalog_product_bundle_selection.option_id
+        JOIN demac_multilocationinventory_stock
+            ON demac_multilocationinventory_stock.product_id = catalog_product_bundle_selection.product_id
+        WHERE
+            required_count > 0
+        AND
+            catalog_product_bundle_option.required = 1
+        AND
+            FIND_IN_SET(catalog_product_bundle_selection.parent_product_id, reindex_entity_ids)
+        GROUP BY
+            Concat(catalog_product_bundle_selection.parent_product_id, "_", catalog_product_bundle_selection.option_id)
+        ) src
+    GROUP BY
+        Concat(src.product_id)) src2
+SET
+    dest.qty = src2.qty,
+    dest.is_in_stock = src2.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = 0
+AND
+    dest.product_id = src2.product_id;
+
+-- STORE SPECIFIC:
+UPDATE demac_multilocationinventory_stock_status_index dest,
+    (SELECT src.store_id,
+        src.product_id,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS is_in_stock,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS qty
+    FROM
+        (SELECT demac_multilocationinventory_stores.store_id AS store_id,
+            catalog_product_bundle_selection.option_id AS option_id,
+            catalog_product_bundle_selection.parent_product_id AS product_id,
+            IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0) AS is_in_stock
+        FROM
+            catalog_product_bundle_selection
+        JOIN demac_multilocationinventory_bundled_indexer_tmp
+            ON demac_multilocationinventory_bundled_indexer_tmp.entity_id = catalog_product_bundle_selection.parent_product_id
+        JOIN catalog_product_bundle_option
+            ON catalog_product_bundle_option.option_id = catalog_product_bundle_selection.option_id
+        JOIN demac_multilocationinventory_stock
+            ON demac_multilocationinventory_stock.product_id = catalog_product_bundle_selection.product_id
+        JOIN demac_multilocationinventory_stores
+            ON demac_multilocationinventory_stock.location_id = demac_multilocationinventory_stores.location_id
+        WHERE
+            required_count > 0
+        AND catalog_product_bundle_option.required = 1
+        AND
+            FIND_IN_SET(catalog_product_bundle_selection.parent_product_id, reindex_entity_ids)
+        GROUP BY
+            Concat(catalog_product_bundle_selection.parent_product_id, "_", demac_multilocationinventory_stores.store_id, "_", catalog_product_bundle_selection.option_id)
+        ) src
+    GROUP  BY Concat(src.product_id, "_", src.store_id)
+    ) src2
+SET
+    dest.qty = src2.qty,
+    dest.is_in_stock = src2.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = src2.store_id
+AND
+    dest.product_id = src2.product_id;
+
+-- CLEANUP:
+DROP TABLE IF EXISTS demac_multilocationinventory_bundled_indexer_tmp;
+END;
+';
+
+
+$sql2 = '
+DROP PROCEDURE IF EXISTS `DEMAC_MLI_REINDEX_ALL`;
+CREATE PROCEDURE `DEMAC_MLI_REINDEX_ALL` ()
+BEGIN
+  UPDATE demac_multilocationinventory_stock_status_index dest,
+       (SELECT stock.product_id                                      AS
+               product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum(
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1,
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               stores.store_id                                       AS store_id
+        FROM   demac_multilocationinventory_stock AS stock
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+               JOIN catalog_product_entity AS product_entity
+                 ON stock.product_id = product_entity.entity_id
+               JOIN demac_multilocationinventory_stores AS stores
+                 ON stock.location_id = stores.location_id
+        WHERE  location.status = 1
+               AND product_entity.type_id IN ("simple", "giftcard")
+        GROUP  BY Concat(stores.store_id, "_", stock.product_id)
+        UNION
+        SELECT stock.product_id                                      AS
+               product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum(
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1,
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               0                                                     AS store_id
+        FROM   demac_multilocationinventory_stock AS stock
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+               JOIN catalog_product_entity AS product_entity
+                 ON stock.product_id = product_entity.entity_id
+        WHERE  location.status = 1
+               AND product_entity.type_id IN ("simple", "giftcard")
+        GROUP  BY stock.product_id
+        UNION
+        SELECT product_entity.entity_id
+               AS product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF(
+               Sum(IF(stock.is_in_stock =
+                      1, stock.qty, 0))
+               AND
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF(
+               Sum(IF(stock.is_in_stock =
+                      1, stock.qty, 0))
+               AND
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               stores.store_id                                       AS store_id
+        FROM   catalog_product_entity AS product_entity
+               JOIN catalog_product_super_link AS link
+                 ON product_entity.entity_id = link.parent_id
+               JOIN demac_multilocationinventory_stock AS stock
+                 ON link.product_id = stock.product_id
+               JOIN demac_multilocationinventory_stores AS stores
+                 ON stock.location_id = stores.location_id
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "configurable"
+        GROUP  BY Concat(stores.store_id, "_", product_entity.entity_id)
+        UNION
+        SELECT product_entity.entity_id
+               AS product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF(
+               Sum(IF(stock.is_in_stock =
+                      1, stock.qty, 0))
+               AND
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, IF(
+               Sum(IF(stock.is_in_stock =
+                      1, stock.qty, 0))
+               AND
+               Sum(stock.is_in_stock) > 0, 1, 0))                    AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               0                                                     AS store_id
+        FROM   catalog_product_entity AS product_entity
+               JOIN catalog_product_super_link AS link
+                 ON product_entity.entity_id = link.parent_id
+               JOIN demac_multilocationinventory_stock AS stock
+                 ON link.product_id = stock.product_id
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "configurable"
+        GROUP  BY product_entity.entity_id
+        UNION
+        SELECT product_entity.entity_id                              AS
+               product_id,
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0))
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS qty,
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0))
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               stores.store_id                                       AS store_id
+        FROM   catalog_product_entity AS product_entity
+               JOIN catalog_product_link AS link
+                 ON product_entity.entity_id = link.product_id
+               JOIN demac_multilocationinventory_stock AS stock
+                 ON link.linked_product_id = stock.product_id
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+               JOIN demac_multilocationinventory_stores AS stores
+                 ON stock.location_id = stores.location_id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "grouped"
+        GROUP  BY Concat(stores.store_id, "_", product_entity.entity_id)
+        UNION
+        SELECT product_entity.entity_id                              AS
+               product_id,
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0))
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS qty,
+               IF(Sum(IF(stock.is_in_stock = 1, stock.qty, 0))
+                  AND Sum(stock.is_in_stock) > 0, 1, 0)              AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               0                                                     AS store_id
+        FROM   catalog_product_entity AS product_entity
+               JOIN catalog_product_link AS link
+                 ON product_entity.entity_id = link.product_id
+               JOIN demac_multilocationinventory_stock AS stock
+                 ON link.linked_product_id = stock.product_id
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "grouped"
+        GROUP  BY product_entity.entity_id
+        UNION
+        SELECT stock.product_id                                      AS
+               product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum(
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1,
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               stores.store_id                                       AS store_id
+        FROM   demac_multilocationinventory_stock AS stock
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+               JOIN catalog_product_entity AS product_entity
+                 ON stock.product_id = product_entity.entity_id
+               JOIN demac_multilocationinventory_stores AS stores
+                 ON stock.location_id = stores.location_id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "virtual"
+        GROUP  BY Concat(stores.store_id, "_", stock.product_id)
+        UNION
+        SELECT stock.product_id                                      AS
+               product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum(
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1,
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               0                                                     AS store_id
+        FROM   demac_multilocationinventory_stock AS stock
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+               JOIN catalog_product_entity AS product_entity
+                 ON stock.product_id = product_entity.entity_id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "virtual"
+        GROUP  BY stock.product_id
+        UNION
+        SELECT stock.product_id                                      AS
+               product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum(
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1,
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               stores.store_id                                       AS store_id
+        FROM   demac_multilocationinventory_stock AS stock
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+               JOIN catalog_product_entity AS product_entity
+                 ON stock.product_id = product_entity.entity_id
+               JOIN demac_multilocationinventory_stores AS stores
+                 ON stock.location_id = stores.location_id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "downloadable"
+        GROUP  BY Concat(stores.store_id, "_", stock.product_id)
+        UNION
+        SELECT stock.product_id                                      AS
+               product_id,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1, Sum(
+               IF(stock.is_in_stock = 1, stock.qty, 0)))             AS qty,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 1,
+               IF(Sum(stock.is_in_stock) > 0, 1, 0))                 AS
+               is_in_stock,
+               IF(Sum(stock.backorders) > 0, 1, 0)                   AS
+               backorders,
+               IF(Group_concat(stock.manage_stock) LIKE "%0%", 0, 1) AS
+               manage_stock,
+               0                                                     AS store_id
+        FROM   demac_multilocationinventory_stock AS stock
+               JOIN demac_multilocationinventory_location AS location
+                 ON stock.location_id = location.id
+               JOIN catalog_product_entity AS product_entity
+                 ON stock.product_id = product_entity.entity_id
+        WHERE  location.status = 1
+               AND product_entity.type_id = "downloadable"
+        GROUP  BY stock.product_id) src
+SET    dest.qty = src.qty,
+       dest.is_in_stock = src.is_in_stock,
+       dest.backorders = src.backorders,
+       dest.manage_stock = src.manage_stock
+WHERE  dest.store_id = src.store_id
+       AND dest.product_id = src.product_id;
+
+-- BUNDLE SECTION
+-- check if all fields are optional
+CREATE temporary TABLE IF NOT EXISTS
+demac_multilocationinventory_bundled_indexer_tmp AS
+  (SELECT catalog_product_entity.entity_id,
+          Sum(catalog_product_bundle_option.required) AS required_count
+   FROM   catalog_product_entity
+          JOIN catalog_product_bundle_option
+            ON catalog_product_bundle_option.parent_id =
+               catalog_product_entity.entity_id
+   WHERE  type_id = "bundle"
+   GROUP  BY catalog_product_entity.entity_id);
+
+-- ALL OPTIONAL: get all child products, if sum of is_in_stock > 0 then set is_in_stock = 1 and qty = some really big number
+-- GLOBAL:
+UPDATE
+    demac_multilocationinventory_stock_status_index dest,
+   (SELECT catalog_product_bundle_selection.parent_product_id AS product_id,
+           IF(Sum(is_in_stock) > 0, 1, 0)                     AS qty,
+           IF(Sum(is_in_stock) > 0, 1, 0)                     AS is_in_stock
+    FROM   catalog_product_bundle_selection
+           JOIN demac_multilocationinventory_bundled_indexer_tmp
+             ON demac_multilocationinventory_bundled_indexer_tmp.entity_id =
+                catalog_product_bundle_selection.parent_product_id
+           JOIN demac_multilocationinventory_stock
+             ON demac_multilocationinventory_stock.product_id =
+                catalog_product_bundle_selection.product_id
+    WHERE  required_count = 0
+    GROUP  BY catalog_product_bundle_selection.parent_product_id) src
+SET
+    dest.qty = src.qty,
+    dest.is_in_stock = src.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = 0
+AND
+    dest.product_id = src.product_id;
+
+-- STORE SPECIFIC:
+UPDATE demac_multilocationinventory_stock_status_index dest,
+    (SELECT demac_multilocationinventory_stores.store_id                        AS store_id,
+           catalog_product_bundle_selection.parent_product_id                   AS product_id,
+           IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0)    AS qty,
+           IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0)    AS is_in_stock
+    FROM   catalog_product_bundle_selection
+        JOIN demac_multilocationinventory_bundled_indexer_tmp
+            ON demac_multilocationinventory_bundled_indexer_tmp.entity_id = catalog_product_bundle_selection.parent_product_id
+        JOIN demac_multilocationinventory_stock
+            ON demac_multilocationinventory_stock.product_id = catalog_product_bundle_selection.product_id
+        JOIN demac_multilocationinventory_stores
+            ON demac_multilocationinventory_stock.location_id = demac_multilocationinventory_stores.location_id
+    WHERE
+        required_count = 0
+    GROUP BY
+        Concat(catalog_product_bundle_selection.parent_product_id, "_",demac_multilocationinventory_stores.store_id)
+    ) src
+SET
+    dest.qty = src.qty,
+    dest.is_in_stock = src.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = src.store_id
+AND
+    dest.product_id = src.product_id;
+
+-- SOME REQUIRED: Verify that each required option has at least one child item in stock (sum is_in_stock grouped by option, if all are greater than 1)
+-- GLOBAL:
+UPDATE
+    demac_multilocationinventory_stock_status_index dest,
+    (SELECT src.product_id AS product_id,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS is_in_stock,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS qty
+    FROM
+        (SELECT catalog_product_bundle_selection.option_id AS option_id,
+            catalog_product_bundle_selection.parent_product_id AS product_id,
+            IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0) AS is_in_stock
+        FROM
+            catalog_product_bundle_selection
+        JOIN demac_multilocationinventory_bundled_indexer_tmp
+            ON demac_multilocationinventory_bundled_indexer_tmp.entity_id = catalog_product_bundle_selection.parent_product_id
+        JOIN catalog_product_bundle_option
+            ON catalog_product_bundle_option.option_id = catalog_product_bundle_selection.option_id
+        JOIN demac_multilocationinventory_stock
+            ON demac_multilocationinventory_stock.product_id = catalog_product_bundle_selection.product_id
+        WHERE
+            required_count > 0
+        AND
+            catalog_product_bundle_option.required = 1
+        GROUP BY
+            Concat(catalog_product_bundle_selection.parent_product_id, "_", catalog_product_bundle_selection.option_id)
+        ) src
+    GROUP BY
+        Concat(src.product_id)) src2
+SET
+    dest.qty = src2.qty,
+    dest.is_in_stock = src2.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = 0
+AND
+    dest.product_id = src2.product_id;
+
+-- STORE SPECIFIC:
+UPDATE demac_multilocationinventory_stock_status_index dest,
+    (SELECT src.store_id,
+        src.product_id,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS is_in_stock,
+        IF(Concat(",", Group_concat(src.is_in_stock), ",") LIKE "%0%", 0, 1) AS qty
+    FROM
+        (SELECT demac_multilocationinventory_stores.store_id AS store_id,
+            catalog_product_bundle_selection.option_id AS option_id,
+            catalog_product_bundle_selection.parent_product_id AS product_id,
+            IF(Sum(demac_multilocationinventory_stock.is_in_stock) > 0, 1, 0) AS is_in_stock
+        FROM
+            catalog_product_bundle_selection
+        JOIN demac_multilocationinventory_bundled_indexer_tmp
+            ON demac_multilocationinventory_bundled_indexer_tmp.entity_id = catalog_product_bundle_selection.parent_product_id
+        JOIN catalog_product_bundle_option
+            ON catalog_product_bundle_option.option_id = catalog_product_bundle_selection.option_id
+        JOIN demac_multilocationinventory_stock
+            ON demac_multilocationinventory_stock.product_id = catalog_product_bundle_selection.product_id
+        JOIN demac_multilocationinventory_stores
+            ON demac_multilocationinventory_stock.location_id = demac_multilocationinventory_stores.location_id
+        WHERE
+            required_count > 0
+        AND catalog_product_bundle_option.required = 1
+        GROUP BY
+            Concat(catalog_product_bundle_selection.parent_product_id, "_", demac_multilocationinventory_stores.store_id, "_", catalog_product_bundle_selection.option_id)
+        ) src
+    GROUP  BY Concat(src.product_id, "_", src.store_id)
+    ) src2
+SET
+    dest.qty = src2.qty,
+    dest.is_in_stock = src2.is_in_stock,
+    dest.backorders = 0,
+    dest.manage_stock = 1
+WHERE
+    dest.store_id = src2.store_id
+AND
+    dest.product_id = src2.product_id;
+
+-- CLEANUP:
+DROP TABLE IF EXISTS demac_multilocationinventory_bundled_indexer_tmp;
+END;
+';
+
+$write = Mage::getSingleton('core/resource')->getConnection('core_write');
+$write->exec($sql);
+$write->exec($sql2);
+
+
+$installer->endSetup();

--- a/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.6-1.2.7.php
+++ b/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.6-1.2.7.php
@@ -1,0 +1,25 @@
+<?php
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+
+$installer->startSetup();
+
+/**
+ * Add "code" column for use when importing/exporting stock data
+ */
+$table      = $installer->getTable('demac_multilocationinventory/location');
+$connection = $installer->getConnection();
+
+$connection->addColumn($table, 'code',
+    array(
+        'type'    => Varien_Db_Ddl_Table::TYPE_TEXT,
+        'length'  => 255,
+        'unique'  => true,
+        'comment' => 'Location code for import',
+        'after'   => 'name'
+    )
+);
+
+$connection->addIndex($table, 'IDX_CODE', 'code', Varien_Db_Adapter_Interface::INDEX_TYPE_UNIQUE);
+
+$installer->endSetup();

--- a/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.7-1.2.8.php
+++ b/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.7-1.2.8.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: MichaelK
+ * Date: 4/9/14
+ * Time: 7:05 AM
+ */
+
+/* @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+
+$installer->startSetup();
+
+$table = $installer->getTable('demac_multilocationinventory/stock');
+
+$connection = $installer->getConnection();
+$connection->addColumn(
+    $table,
+    'min_qty',
+    array(
+        'type'      => Varien_Db_Ddl_Table::TYPE_DECIMAL,
+        'scale'     => 4,
+        'precision' => 12,
+        'nullable'  => false,
+        'default'   => '0.0000',
+        'comment'   => 'Min Qty'
+    )
+);
+
+$installer->endSetup();

--- a/app/design/adminhtml/default/default/template/demac/catalog_multilocationinventory.phtml
+++ b/app/design/adminhtml/default/default/template/demac/catalog_multilocationinventory.phtml
@@ -7,7 +7,7 @@
             <table cellspacing="0" class="form-list">
                 <tr>
                     <td class="label">
-                        <label for="multilocationinventory_global_inventory">Global Inventory</label>
+                        <label for="multilocationinventory_global_inventory"><?php echo $this->__('Global Inventory') ?></label>
                     </td>
                     <td class="value">
                         <span class="bold"><?php echo $this->getGlobalInventory() ?></span>
@@ -15,7 +15,7 @@
                 </tr>
                 <tr>
                     <td class="label">
-                        <label for="multilocationinventory_global_location">Scope Inventory</label>
+                        <label for="multilocationinventory_global_location"><?php echo $this->__('Scope Inventory') ?></label>
                     </td>
                     <td class="value">
                         <span class="bold"><?php echo $this->getScopeInventory() ?></span>
@@ -29,11 +29,12 @@
             <table cellspacing="0" class="data border">
                 <thead>
                 <tr class="headings">
-                    <th>Location</th>
-                    <th>Quantity</th>
-                    <th>Backorders</th>
-                    <th>Stock Status</th>
-                    <th>Manage Stock</th>
+                    <th><?php echo $this->__('Location') ?></th>
+                    <th><?php echo $this->__('Quantity') ?></th>
+                    <th><?php echo $this->__('Qty for Item\'s Status to Become Out of Stock') ?></th>
+                    <th><?php echo $this->__('Backorders') ?></th>
+                    <th><?php echo $this->__('Stock Status') ?></th>
+                    <th><?php echo $this->__('Manage Stock') ?></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -50,6 +51,13 @@
                                    value="<?php echo $_location['qty'] ?>"/>
                         </td>
                         <td>
+                            <input type="text"
+                                   name="multilocationinventory[<?php echo $_location['id'] ?>][min_qty]"
+                                   class="input-text validate-number"
+                                <?php echo ($_location['manage_stock'] === "1") ? '' : 'style="visibility:hidden;"' ?>
+                                   value="<?php echo $_location['min_qty'] ?>"/>
+                        </td>
+                        <td>
                             <select name="multilocationinventory[<?php echo $_location['id'] ?>][backorders]"
                                     style="width:86%;<?php echo ($_location['manage_stock'] === "1") ? '' : 'visibility:hidden;' ?>" class="select">
                                 <?php if($_location['backorders'] == ''): ?>
@@ -57,11 +65,11 @@
                                 <?php endif; ?>
                                 <option
                                     value="1" <?php echo ($_location['backorders'] === "1") ? 'selected="selected"' : '' ?>>
-                                    Yes
+                                    <?php echo $this->__('Yes') ?>
                                 </option>
                                 <option
                                     value="0" <?php echo ($_location['backorders'] !== "1") ? 'selected="selected"' : '' ?>>
-                                    No
+                                    <?php echo $this->__('No') ?>
                                 </option>
                             </select>
                         </td>
@@ -70,11 +78,11 @@
                                     style="width:86%;<?php echo ($_location['manage_stock'] === "1") ? '' : 'visibility:hidden;' ?>" class="select">
                                 <option
                                     value="1" <?php echo ($_location['is_in_stock'] === "1") ? 'selected="selected"' : '' ?>>
-                                    In Stock
+                                    <?php echo $this->__('In Stock') ?>
                                 </option>
                                 <option
                                     value="0" <?php echo ($_location['is_in_stock'] !== "1") ? 'selected="selected"' : '' ?>>
-                                    Out Of Stock
+                                    <?php echo $this->__('Out Of Stock') ?>
                                 </option>
                             </select>
                         </td>
@@ -83,11 +91,11 @@
                                     style="width:86%;" class="select demac_multilocationinventory_manage_stock">
                                 <option
                                     value="1" <?php echo ($_location['manage_stock'] === "1") ? 'selected="selected"' : '' ?>>
-                                    Yes
+                                    <?php echo $this->__('Yes') ?>
                                 </option>
                                 <option
                                     value="0" <?php echo ($_location['manage_stock'] !== "1") ? 'selected="selected"' : '' ?>>
-                                    No
+                                    <?php echo $this->__('No') ?>
                                 </option>
                             </select>
                         </td>

--- a/sample_import.csv
+++ b/sample_import.csv
@@ -1,0 +1,3 @@
+sku,stock_location,is_in_stock,qty,backorders
+SAMPLESKU,location_1,1,54,0
+,location_2,0,0,0


### PR DESCRIPTION
This pull request adds the following features:

* Bundle product indexing,
* Threshold on product location level,
* Additional fields to the import,

Notes: Bundle will only work when set to "Manage Stock" -> "No" and letting the child products define when a product is in our out of stock.

Threshold is set-up on the level of product and locations so you can have different location thresholds on a product by product basis.

Covers: #31 