### PR TITLE
Optimisation -> no need to join on stock table since we only need ids…

### DIFF
--- a/app/code/community/Demac/MultiLocationInventory/Helper/Location.php
+++ b/app/code/community/Demac/MultiLocationInventory/Helper/Location.php
@@ -20,11 +20,7 @@ class Demac_MultiLocationInventory_Helper_Location extends Mage_Core_Helper_Abst
 
         $locationsCollection = Mage::getModel('demac_multilocationinventory/location')
             ->getCollection()
-            ->joinStockDataOnProductAndStoreView(false, $storeId);
-        $locationsCollection
-            ->getSelect()
-            ->group('main_table.id');
-
+            ->joinOnStoreView($storeId);
 
         $locationIds = $locationsCollection->getAllIds();
 

--- a/app/code/community/Demac/MultiLocationInventory/Model/Resource/Location/Collection.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Resource/Location/Collection.php
@@ -169,6 +169,37 @@ class Demac_MultiLocationInventory_Model_Resource_Location_Collection extends Ma
         return $this;
     }
 
+
+    /**
+     * Join location collection based on store view id .
+     *
+     * @param bool $storeViewId
+     *
+     * @return Demac_MultiLocationInventory_Model_Resource_Location_Collection
+     */
+    public function joinOnStoreView($storeViewId = false)
+    {
+        $this
+            ->getSelect()
+            ->join(
+                array(
+                    'stores' => Mage::getSingleton('core/resource')->getTableName('demac_multilocationinventory/stores')
+                ),
+                'main_table.id = stores.location_id',
+                array()
+            );
+
+        if($storeViewId) {
+
+            $this->addFieldToFilter('stores.store_id', $storeViewId);
+        }
+
+        $this->getSelect()->group('main_table.id');
+
+
+        return $this;
+    }
+
     /**
      * @return Varien_Data_Collection_Db
      */


### PR DESCRIPTION
… of locations by store

It is useless to join on the stock table since we only need ids of locations by store in the priorization function.

In our site, we have 2.8 millions of rows in the stock table. The join takes ~0.7 second for each product in the quote. Which is way too long in a production environment before the order confirmation.
With this upgrade, it takes ~0.05 second.
Thanks for the plugin by the way. It works great ! We have ~90 locations with 20000 products in total and it's perfect !