### PR TITLE
Indexation on order from synchronous to asynchronous to speed up orde…

### DIFF
--- a/app/code/community/Demac/MultiLocationInventory/Model/Order/Asynchronous/Index.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Order/Asynchronous/Index.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Class Demac_MultiLocationInventory_Model_Order_Asynchronous_Index
+ */
+class Demac_MultiLocationInventory_Model_Order_Asynchronous_Index extends Mage_Core_Model_Abstract
+{
+    /**
+     * Init Model
+     */
+    public function _construct()
+    {
+        parent::_construct();
+        $this->_init('demac_multilocationinventory/order_asynchronous_index');
+    }
+}

--- a/app/code/community/Demac/MultiLocationInventory/Model/Resource/Order/Asynchronous/Index.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Resource/Order/Asynchronous/Index.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Class Demac_MultiLocationInventory_Model_Resource_Order_Asynchronous_Index
+ */
+class Demac_MultiLocationInventory_Model_Resource_Order_Asynchronous_Index extends Mage_Core_Model_Resource_Db_Abstract
+{
+
+    /**
+     * Init Resource
+     */
+    protected function _construct()
+    {
+        $this->_init('demac_multilocationinventory/order_asynchronous_index', 'id');
+    }
+}

--- a/app/code/community/Demac/MultiLocationInventory/Model/Resource/Order/Asynchronous/Index/Collection.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Resource/Order/Asynchronous/Index/Collection.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Class Demac_MultiLocationInventory_Model_Resource_Order_Stock_Source_Collection
+ */
+class Demac_MultiLocationInventory_Model_Resource_Order_Asynchronous_Index_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
+{
+    /**
+     * Init collection
+     */
+    protected function _construct()
+    {
+        $this->_init('demac_multilocationinventory/order_asynchronous_index');
+    }
+}

--- a/app/code/community/Demac/MultiLocationInventory/etc/config.xml
+++ b/app/code/community/Demac/MultiLocationInventory/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Demac_MultiLocationInventory>
-            <version>1.2.8</version>
+            <version>1.2.9</version>
         </Demac_MultiLocationInventory>
     </modules>
     <global>
@@ -72,6 +72,9 @@
                     <order_stock_source>
                         <table>demac_multilocationinventory_order_stock_source</table>
                     </order_stock_source>
+                    <order_asynchronous_index>
+                        <table>demac_multilocationinventory_order_asynchronous_index</table>
+                    </order_asynchronous_index>
                 </entities>
             </demac_multilocationinventory_resource>
             <cataloginventory>
@@ -117,6 +120,14 @@
             </demac_multilocationinventory_setup>
         </resources>
     </global>
+    <crontab>
+        <jobs>
+            <demac_multilocationinventory>
+                <schedule><cron_expr>*/1 * * * *</cron_expr></schedule>
+                <run><model>demac_multilocationinventory/observer::indexStockAfterOrder</model></run>
+            </demac_multilocationinventory>
+        </jobs>
+    </crontab>
     <frontend>
         <translate>
             <modules>

--- a/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.8-1.2.9.php
+++ b/app/code/community/Demac/MultiLocationInventory/sql/demac_multilocationinventory_setup/upgrade-1.2.8-1.2.9.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: MichaelK
+ * Date: 4/9/14
+ * Time: 7:05 AM
+ */
+
+/* @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+
+$installer->startSetup();
+/**
+ * Create table 'demac_multilocationinventory/order_asynchronous_index'
+ */
+$table = $installer->getConnection()
+    ->newTable($installer->getTable('demac_multilocationinventory/order_asynchronous_index'))
+    ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+        'identity' => true,
+        'unsigned' => true,
+        'nullable' => false,
+        'primary'  => true,
+    ), 'Index Id')
+    ->addColumn('product_id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+        'unsigned' => true,
+        'nullable' => false,
+        'unique'  => true,
+    ), 'Product ID')
+    ->setComment('Asynchronous indexation after order');
+
+$installer->getConnection()->createTable($table);
+$installer->endSetup();


### PR DESCRIPTION
…r confirmation

Problem : the product reindex during order confirmation was taking 15-45 seconds to finish.
My solution is to make the reindexation asynchronous.
So i created a cron which checks every minute if there's products to reindex.
The products ids are stocked in a table `order_asynchronous_index`.

Thanks again for the module :).