### PR TITLE
Fix/reindex on create product outside admin scope

### DIFF
--- a/app/code/community/Demac/MultiLocationInventory/Model/Admin/Observer.php
+++ b/app/code/community/Demac/MultiLocationInventory/Model/Admin/Observer.php
@@ -68,6 +68,69 @@ class Demac_MultiLocationInventory_Model_Admin_Observer
     }
 
     /**
+     * @param $observer
+     * @return $this
+     */
+    public function persistMLIIndexProductSaveOnImport($observer)
+    {
+        /** @var string $_node */
+        $_node = 'global/events/'.$observer->getEvent()->getName().'/observers/multi_location_inventory_product_save_on_import/import';
+
+        /** @var Mage_Core_Model_Config_Element $_import_argument */
+        $_import_argument = Mage::getConfig()->getNode($_node);
+
+        // If calling from Admin interface then walk away
+        if (!$_import_argument) {
+            return $this;
+        }
+        /** @var Mage_Core_Controller_Request_Http $_request */
+        $_request = Mage::app()->getRequest();
+
+        /** @var int $_product_id */
+        $_product_id = $observer->getEvent()->getProduct()->getId();
+        /** @var array $_stock */
+        $_stock = $_request->getPost("stock");
+        if ($_product_id && $_stock) {
+            /** @var int $_location_id */
+            $_location_id = $_stock["location_id"];
+            // Hydrate input-data private variable
+            $this->inputData[$_location_id] = $_stock;
+            //$input_multiLocationInventoryDataIds = [$_location_id];
+
+            //Get select collection to find all existing inventory data to update...
+            /** @var Demac_MultiLocationInventory_Model_Resource_Stock_Collection $_collection */
+            $_collection = Mage::getModel('demac_multilocationinventory/stock')
+                ->getCollection()
+                ->addFieldToSelect(array('stock_id', 'location_id'))
+                ->addFieldToFilter('location_id', $_location_id)
+                ->addFieldToFilter('product_id', array('eq' => $_product_id)
+                );
+
+            //Iterate through the collection of inventory data to update...
+            if ($_collection->getSize() > 0) {
+                Mage::getSingleton('core/resource_iterator')->walk(
+                    $_collection->getSelect(),
+                    array(
+                        array($this, '_updateInventoryDataIterate')
+                    ),
+                    array(
+                        'invoker' => $this
+                    )
+                );
+            }
+
+            //Create remaining stock data
+            /** @var array $_stock */
+            $_stock = array(
+                'location_id' => $_location_id,
+                'product_id' => $_product_id,
+            );
+            $this->_updateInventoryData($_stock);
+        }
+        Mage::getModel('demac_multilocationinventory/indexer')->reindex($_product_id);
+    }
+
+    /**
      * Wrapper for the update stock iterator to push data into other functions in a generic format.
      *
      * @param $args

--- a/app/code/community/Demac/MultiLocationInventory/etc/config.xml
+++ b/app/code/community/Demac/MultiLocationInventory/etc/config.xml
@@ -23,6 +23,15 @@
                     </multi_location_inventory_import>
                 </observers>
             </catalog_product_import_finish_before>
+            <catalog_product_save_after>
+                <observers>
+                    <multi_location_inventory_product_save_on_import>
+                        <class>Demac_MultiLocationInventory_Model_Admin_Observer</class>
+                        <method>persistMLIIndexProductSaveOnImport</method>
+                        <import>1</import>
+                    </multi_location_inventory_product_save_on_import>
+                </observers>
+            </catalog_product_save_after>
         </events>
         <index>
             <indexer>


### PR DESCRIPTION
This fixes an issue i've come across regarding importing product's stock outside admin interface.
It turns out that when importing product's stock abroad from an interface other thatn admin back-office, a file based import process for instance, the method multiLocationInventoryProductSave is not being dispatched since it's tied to adminhtml node in the config file. 
So, this fix consists of creating a new event under global node and defining an argument to make sure inside attached method that it's only being called in this context. Then in the observer's method defined i perform the proper index table persistence, based on the product's stock related data.
An array must be defined which will be passed out trough request object, this is responsibility of the importer. Such an array must containg at least the same keys than the one obtained by: 
Mage::app()->getRequest()->getPost('multilocationinventory');

Valid to say that this fix could include way much refactoring. 